### PR TITLE
eyeServos - adds second table to the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+TOF/src/TOF.cpp
+TOF/target/*
+TOF/.vscode/*
+TOF/photon_firmware*
+TOF_aim/src/TOF_aim.cpp
+TOF_aim/target/*
+TOF_aim/.vscode/*
+TOF_aim/photon_firmware*


### PR DESCRIPTION
Currently puts out the num_targets table but is easily changed. See lines 144/145 in the .ino file.

Also updated .gitignore to not track files in /target or the firmware files from a compile.
