### PR TITLE
Eye servos: v9 servo control added

### DIFF
--- a/TOF_aim/TOF_aim.code-workspace
+++ b/TOF_aim/TOF_aim.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+    "settings": {
+        "cortex-debug.openocdPath": "${command:particle.getDebuggerOpenocdPath}"
+    }
+}

--- a/TOF_aim/src/Adafruit_PWMServoDriver.cpp
+++ b/TOF_aim/src/Adafruit_PWMServoDriver.cpp
@@ -1,0 +1,360 @@
+/*!
+ *  @file Adafruit_PWMServoDriver.cpp
+ *
+ *  @mainpage Adafruit 16-channel PWM & Servo driver
+ *
+ *  @section intro_sec Introduction
+ *
+ *  This is a library for the 16-channel PWM & Servo driver.
+ *
+ *  Designed specifically to work with the Adafruit PWM & Servo driver.
+ *
+ *  Pick one up today in the adafruit shop!
+ *  ------> https://www.adafruit.com/product/815
+ *
+ *  These displays use I2C to communicate, 2 pins are required to interface.
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit andopen-source hardware by purchasing products
+ *  from Adafruit!
+ *
+ *  @section author Author
+ *
+ *  Limor Fried/Ladyada (Adafruit Industries).
+ *
+ *  @section license License
+ *
+ *  BSD license, all text above must be included in any redistribution
+ */
+
+#include "Adafruit_PWMServoDriver.h"
+#include <Wire.h>
+
+//#define ENABLE_DEBUG_OUTPUT
+
+/*!
+ *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
+ * TwoWire interface
+ */
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver()
+    : _i2caddr(PCA9685_I2C_ADDRESS), _i2c(&Wire) {}
+
+/*!
+ *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
+ * TwoWire interface
+ *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
+ */
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr)
+    : _i2caddr(addr), _i2c(&Wire) {}
+
+/*!
+ *  @brief  Instantiates a new PCA9685 PWM driver chip with the I2C address on a
+ * TwoWire interface
+ *  @param  addr The 7-bit I2C address to locate this chip, default is 0x40
+ *  @param  i2c  A reference to a 'TwoWire' object that we'll use to communicate
+ *  with
+ */
+Adafruit_PWMServoDriver::Adafruit_PWMServoDriver(const uint8_t addr,
+                                                 TwoWire &i2c)
+    : _i2caddr(addr), _i2c(&i2c) {}
+
+/*!
+ *  @brief  Setups the I2C interface and hardware
+ *  @param  prescale
+ *          Sets External Clock (Optional)
+ */
+void Adafruit_PWMServoDriver::begin(uint8_t prescale) {
+  _i2c->begin();
+  reset();
+  if (prescale) {
+    setExtClk(prescale);
+  } else {
+    // set a default frequency
+    setPWMFreq(1000);
+  }
+  // set the default internal frequency
+  setOscillatorFrequency(FREQUENCY_OSCILLATOR);
+}
+
+/*!
+ *  @brief  Sends a reset command to the PCA9685 chip over I2C
+ */
+void Adafruit_PWMServoDriver::reset() {
+  write8(PCA9685_MODE1, MODE1_RESTART);
+  delay(10);
+}
+
+/*!
+ *  @brief  Puts board into sleep mode
+ */
+void Adafruit_PWMServoDriver::sleep() {
+  uint8_t awake = read8(PCA9685_MODE1);
+  uint8_t sleep = awake | MODE1_SLEEP; // set sleep bit high
+  write8(PCA9685_MODE1, sleep);
+  delay(5); // wait until cycle ends for sleep to be active
+}
+
+/*!
+ *  @brief  Wakes board from sleep
+ */
+void Adafruit_PWMServoDriver::wakeup() {
+  uint8_t sleep = read8(PCA9685_MODE1);
+  uint8_t wakeup = sleep & ~MODE1_SLEEP; // set sleep bit low
+  write8(PCA9685_MODE1, wakeup);
+}
+
+/*!
+ *  @brief  Sets EXTCLK pin to use the external clock
+ *  @param  prescale
+ *          Configures the prescale value to be used by the external clock
+ */
+void Adafruit_PWMServoDriver::setExtClk(uint8_t prescale) {
+  uint8_t oldmode = read8(PCA9685_MODE1);
+  uint8_t newmode = (oldmode & ~MODE1_RESTART) | MODE1_SLEEP; // sleep
+  write8(PCA9685_MODE1, newmode); // go to sleep, turn off internal oscillator
+
+  // This sets both the SLEEP and EXTCLK bits of the MODE1 register to switch to
+  // use the external clock.
+  write8(PCA9685_MODE1, (newmode |= MODE1_EXTCLK));
+
+  write8(PCA9685_PRESCALE, prescale); // set the prescaler
+
+  delay(5);
+  // clear the SLEEP bit to start
+  write8(PCA9685_MODE1, (newmode & ~MODE1_SLEEP) | MODE1_RESTART | MODE1_AI);
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Mode now 0x");
+  Serial.println(read8(PCA9685_MODE1), HEX);
+#endif
+}
+
+/*!
+ *  @brief  Sets the PWM frequency for the entire chip, up to ~1.6 KHz
+ *  @param  freq Floating point frequency that we will attempt to match
+ */
+void Adafruit_PWMServoDriver::setPWMFreq(float freq) {
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Attempting to set freq ");
+  Serial.println(freq);
+#endif
+  // Range output modulation frequency is dependant on oscillator
+  if (freq < 1)
+    freq = 1;
+  if (freq > 3500)
+    freq = 3500; // Datasheet limit is 3052=50MHz/(4*4096)
+
+  float prescaleval = ((_oscillator_freq / (freq * 4096.0)) + 0.5) - 1;
+  if (prescaleval < PCA9685_PRESCALE_MIN)
+    prescaleval = PCA9685_PRESCALE_MIN;
+  if (prescaleval > PCA9685_PRESCALE_MAX)
+    prescaleval = PCA9685_PRESCALE_MAX;
+  uint8_t prescale = (uint8_t)prescaleval;
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Final pre-scale: ");
+  Serial.println(prescale);
+#endif
+
+  uint8_t oldmode = read8(PCA9685_MODE1);
+  uint8_t newmode = (oldmode & ~MODE1_RESTART) | MODE1_SLEEP; // sleep
+  write8(PCA9685_MODE1, newmode);                             // go to sleep
+  write8(PCA9685_PRESCALE, prescale); // set the prescaler
+  write8(PCA9685_MODE1, oldmode);
+  delay(5);
+  // This sets the MODE1 register to turn on auto increment.
+  write8(PCA9685_MODE1, oldmode | MODE1_RESTART | MODE1_AI);
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Mode now 0x");
+  Serial.println(read8(PCA9685_MODE1), HEX);
+#endif
+}
+
+/*!
+ *  @brief  Sets the output mode of the PCA9685 to either
+ *  open drain or push pull / totempole.
+ *  Warning: LEDs with integrated zener diodes should
+ *  only be driven in open drain mode.
+ *  @param  totempole Totempole if true, open drain if false.
+ */
+void Adafruit_PWMServoDriver::setOutputMode(bool totempole) {
+  uint8_t oldmode = read8(PCA9685_MODE2);
+  uint8_t newmode;
+  if (totempole) {
+    newmode = oldmode | MODE2_OUTDRV;
+  } else {
+    newmode = oldmode & ~MODE2_OUTDRV;
+  }
+  write8(PCA9685_MODE2, newmode);
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Setting output mode: ");
+  Serial.print(totempole ? "totempole" : "open drain");
+  Serial.print(" by setting MODE2 to ");
+  Serial.println(newmode);
+#endif
+}
+
+/*!
+ *  @brief  Reads set Prescale from PCA9685
+ *  @return prescale value
+ */
+uint8_t Adafruit_PWMServoDriver::readPrescale(void) {
+  return read8(PCA9685_PRESCALE);
+}
+
+/*!
+ *  @brief  Gets the PWM output of one of the PCA9685 pins
+ *  @param  num One of the PWM output pins, from 0 to 15
+ *  @return requested PWM output value
+ */
+uint8_t Adafruit_PWMServoDriver::getPWM(uint8_t num) {
+  _i2c->requestFrom((int)_i2caddr, PCA9685_LED0_ON_L + 4 * num, (int)4);
+  return _i2c->read();
+}
+
+/*!
+ *  @brief  Sets the PWM output of one of the PCA9685 pins
+ *  @param  num One of the PWM output pins, from 0 to 15
+ *  @param  on At what point in the 4096-part cycle to turn the PWM output ON
+ *  @param  off At what point in the 4096-part cycle to turn the PWM output OFF
+ */
+void Adafruit_PWMServoDriver::setPWM(uint8_t num, uint16_t on, uint16_t off) {
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Setting PWM ");
+  Serial.print(num);
+  Serial.print(": ");
+  Serial.print(on);
+  Serial.print("->");
+  Serial.println(off);
+#endif
+
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(PCA9685_LED0_ON_L + 4 * num);
+  _i2c->write(on);
+  _i2c->write(on >> 8);
+  _i2c->write(off);
+  _i2c->write(off >> 8);
+  _i2c->endTransmission();
+}
+
+/*!
+ *   @brief  Helper to set pin PWM output. Sets pin without having to deal with
+ * on/off tick placement and properly handles a zero value as completely off and
+ * 4095 as completely on.  Optional invert parameter supports inverting the
+ * pulse for sinking to ground.
+ *   @param  num One of the PWM output pins, from 0 to 15
+ *   @param  val The number of ticks out of 4096 to be active, should be a value
+ * from 0 to 4095 inclusive.
+ *   @param  invert If true, inverts the output, defaults to 'false'
+ */
+void Adafruit_PWMServoDriver::setPin(uint8_t num, uint16_t val, bool invert) {
+  // Clamp value between 0 and 4095 inclusive.
+  val = min(val, (uint16_t)4095);
+  if (invert) {
+    if (val == 0) {
+      // Special value for signal fully on.
+      setPWM(num, 4096, 0);
+    } else if (val == 4095) {
+      // Special value for signal fully off.
+      setPWM(num, 0, 4096);
+    } else {
+      setPWM(num, 0, 4095 - val);
+    }
+  } else {
+    if (val == 4095) {
+      // Special value for signal fully on.
+      setPWM(num, 4096, 0);
+    } else if (val == 0) {
+      // Special value for signal fully off.
+      setPWM(num, 0, 4096);
+    } else {
+      setPWM(num, 0, val);
+    }
+  }
+}
+
+/*!
+ *  @brief  Sets the PWM output of one of the PCA9685 pins based on the input
+ * microseconds, output is not precise
+ *  @param  num One of the PWM output pins, from 0 to 15
+ *  @param  Microseconds The number of Microseconds to turn the PWM output ON
+ */
+void Adafruit_PWMServoDriver::writeMicroseconds(uint8_t num,
+                                                uint16_t Microseconds) {
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print("Setting PWM Via Microseconds on output");
+  Serial.print(num);
+  Serial.print(": ");
+  Serial.print(Microseconds);
+  Serial.println("->");
+#endif
+
+  double pulse = Microseconds;
+  double pulselength;
+  pulselength = 1000000; // 1,000,000 us per second
+
+  // Read prescale
+  uint16_t prescale = readPrescale();
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print(prescale);
+  Serial.println(" PCA9685 chip prescale");
+#endif
+
+  // Calculate the pulse for PWM based on Equation 1 from the datasheet section
+  // 7.3.5
+  prescale += 1;
+  pulselength *= prescale;
+  pulselength /= _oscillator_freq;
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print(pulselength);
+  Serial.println(" us per bit");
+#endif
+
+  pulse /= pulselength;
+
+#ifdef ENABLE_DEBUG_OUTPUT
+  Serial.print(pulse);
+  Serial.println(" pulse for PWM");
+#endif
+
+  setPWM(num, 0, pulse);
+}
+
+/*!
+ *  @brief  Getter for the internally tracked oscillator used for freq
+ * calculations
+ *  @returns The frequency the PCA9685 thinks it is running at (it cannot
+ * introspect)
+ */
+uint32_t Adafruit_PWMServoDriver::getOscillatorFrequency(void) {
+  return _oscillator_freq;
+}
+
+/*!
+ *  @brief Setter for the internally tracked oscillator used for freq
+ * calculations
+ *  @param freq The frequency the PCA9685 should use for frequency calculations
+ */
+void Adafruit_PWMServoDriver::setOscillatorFrequency(uint32_t freq) {
+  _oscillator_freq = freq;
+}
+
+/******************* Low level I2C interface */
+uint8_t Adafruit_PWMServoDriver::read8(uint8_t addr) {
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(addr);
+  _i2c->endTransmission();
+
+  _i2c->requestFrom((uint8_t)_i2caddr, (uint8_t)1);
+  return _i2c->read();
+}
+
+void Adafruit_PWMServoDriver::write8(uint8_t addr, uint8_t d) {
+  _i2c->beginTransmission(_i2caddr);
+  _i2c->write(addr);
+  _i2c->write(d);
+  _i2c->endTransmission();
+}

--- a/TOF_aim/src/Adafruit_PWMServoDriver.h
+++ b/TOF_aim/src/Adafruit_PWMServoDriver.h
@@ -1,0 +1,105 @@
+/*!
+ *  @file Adafruit_PWMServoDriver.h
+ *
+ *  This is a library for our Adafruit 16-channel PWM & Servo driver.
+ *
+ *  Designed specifically to work with the Adafruit 16-channel PWM & Servo
+ * driver.
+ *
+ *  Pick one up today in the adafruit shop!
+ *  ------> https://www.adafruit.com/product/815
+ *
+ *  These driver use I2C to communicate, 2 pins are required to interface.
+ *  For Arduino UNOs, thats SCL -> Analog 5, SDA -> Analog 4.
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit andopen-source hardware by purchasing products
+ *  from Adafruit!
+ *
+ *  Limor Fried/Ladyada (Adafruit Industries).
+ *
+ *  BSD license, all text above must be included in any redistribution
+ */
+#ifndef _ADAFRUIT_PWMServoDriver_H
+#define _ADAFRUIT_PWMServoDriver_H
+
+#include <Arduino.h>
+#include <Wire.h>
+
+// REGISTER ADDRESSES
+#define PCA9685_MODE1 0x00      /**< Mode Register 1 */
+#define PCA9685_MODE2 0x01      /**< Mode Register 2 */
+#define PCA9685_SUBADR1 0x02    /**< I2C-bus subaddress 1 */
+#define PCA9685_SUBADR2 0x03    /**< I2C-bus subaddress 2 */
+#define PCA9685_SUBADR3 0x04    /**< I2C-bus subaddress 3 */
+#define PCA9685_ALLCALLADR 0x05 /**< LED All Call I2C-bus address */
+#define PCA9685_LED0_ON_L 0x06  /**< LED0 on tick, low byte*/
+#define PCA9685_LED0_ON_H 0x07  /**< LED0 on tick, high byte*/
+#define PCA9685_LED0_OFF_L 0x08 /**< LED0 off tick, low byte */
+#define PCA9685_LED0_OFF_H 0x09 /**< LED0 off tick, high byte */
+// etc all 16:  LED15_OFF_H 0x45
+#define PCA9685_ALLLED_ON_L 0xFA  /**< load all the LEDn_ON registers, low */
+#define PCA9685_ALLLED_ON_H 0xFB  /**< load all the LEDn_ON registers, high */
+#define PCA9685_ALLLED_OFF_L 0xFC /**< load all the LEDn_OFF registers, low */
+#define PCA9685_ALLLED_OFF_H 0xFD /**< load all the LEDn_OFF registers,high */
+#define PCA9685_PRESCALE 0xFE     /**< Prescaler for PWM output frequency */
+#define PCA9685_TESTMODE 0xFF     /**< defines the test mode to be entered */
+
+// MODE1 bits
+#define MODE1_ALLCAL 0x01  /**< respond to LED All Call I2C-bus address */
+#define MODE1_SUB3 0x02    /**< respond to I2C-bus subaddress 3 */
+#define MODE1_SUB2 0x04    /**< respond to I2C-bus subaddress 2 */
+#define MODE1_SUB1 0x08    /**< respond to I2C-bus subaddress 1 */
+#define MODE1_SLEEP 0x10   /**< Low power mode. Oscillator off */
+#define MODE1_AI 0x20      /**< Auto-Increment enabled */
+#define MODE1_EXTCLK 0x40  /**< Use EXTCLK pin clock */
+#define MODE1_RESTART 0x80 /**< Restart enabled */
+// MODE2 bits
+#define MODE2_OUTNE_0 0x01 /**< Active LOW output enable input */
+#define MODE2_OUTNE_1                                                          \
+  0x02 /**< Active LOW output enable input - high impedience */
+#define MODE2_OUTDRV 0x04 /**< totem pole structure vs open-drain */
+#define MODE2_OCH 0x08    /**< Outputs change on ACK vs STOP */
+#define MODE2_INVRT 0x10  /**< Output logic state inverted */
+
+#define PCA9685_I2C_ADDRESS 0x40      /**< Default PCA9685 I2C Slave Address */
+#define FREQUENCY_OSCILLATOR 25000000 /**< Int. osc. frequency in datasheet */
+
+#define PCA9685_PRESCALE_MIN 3   /**< minimum prescale value */
+#define PCA9685_PRESCALE_MAX 255 /**< maximum prescale value */
+
+/*!
+ *  @brief  Class that stores state and functions for interacting with PCA9685
+ * PWM chip
+ */
+class Adafruit_PWMServoDriver {
+public:
+  Adafruit_PWMServoDriver();
+  Adafruit_PWMServoDriver(const uint8_t addr);
+  Adafruit_PWMServoDriver(const uint8_t addr, TwoWire &i2c);
+  void begin(uint8_t prescale = 0);
+  void reset();
+  void sleep();
+  void wakeup();
+  void setExtClk(uint8_t prescale);
+  void setPWMFreq(float freq);
+  void setOutputMode(bool totempole);
+  uint8_t getPWM(uint8_t num);
+  void setPWM(uint8_t num, uint16_t on, uint16_t off);
+  void setPin(uint8_t num, uint16_t val, bool invert = false);
+  uint8_t readPrescale(void);
+  void writeMicroseconds(uint8_t num, uint16_t Microseconds);
+
+  void setOscillatorFrequency(uint32_t freq);
+  uint32_t getOscillatorFrequency(void);
+
+private:
+  uint8_t _i2caddr;
+  TwoWire *_i2c;
+
+  uint32_t _oscillator_freq;
+  uint8_t read8(uint8_t addr);
+  void write8(uint8_t addr, uint8_t d);
+};
+
+#endif

--- a/TOF_aim/src/TOF_aim.ino
+++ b/TOF_aim/src/TOF_aim.ino
@@ -31,6 +31,19 @@
 
 #include <SparkFun_VL53L5CX_Library.h> //http://librarymanager/All#SparkFun_VL53L5CX
 
+#include <Adafruit_PWMServoDriver.h>
+#include <eyeservosettings.h>
+
+Adafruit_PWMServoDriver pwm_; 
+// Servo Numbers for the Servo Driver board
+#define X_SERVO 0
+#define Y_SERVO 1
+#define L_UPPERLID_SERVO 2
+#define L_LOWERLID_SERVO 3
+#define R_UPPERLID_SERVO 4
+#define R_LOWERLID_SERVO 5
+
+
 // used in main loop to move cursor to the top of the displayed table
 #define CURSOR_RESET_ROWS 22
 
@@ -109,7 +122,21 @@ void setup()
     prettyPrint(calibration);
     Serial.println("End of calibration data\n");
   }
-
+    
+    // set up eyes and have the lids open
+    pwm_ = Adafruit_PWMServoDriver();
+    pwm_.begin(); 
+    pwm_.setPWMFreq(60);  // Analog servos run at ~60 Hz updates
+    pwm_.setPWM(L_LOWERLID_SERVO, 0, LEFT_LOWER_OPEN);
+    pwm_.setPWM(R_LOWERLID_SERVO, 0, RIGHT_LOWER_OPEN);
+    pwm_.setPWM(L_UPPERLID_SERVO, 0, LEFT_UPPER_OPEN);
+    pwm_.setPWM(R_UPPERLID_SERVO, 0, RIGHT_UPPER_OPEN);
+    moveEyes(0,0);
+    delay(1000);
+    moveEyes(50,50);
+    delay(1000);
+    moveEyes(100,100);
+    delay (1000);
 
 
   // indicate that setup() is complete
@@ -200,9 +227,18 @@ void loop()
 
       // XXX overwrite the previous display
       moveTerminalCursorUp(CURSOR_RESET_ROWS);
+
+        //decide where to point the eyes
+        // x,y 0-100
+        moveEyes(focusX * 10 ,focusY * 10);
+
     }
   }
   delay(5); //Small delay between polling
+
+
+
+
 //  delay(3000);  // longer delay to ponder results
 }
 
@@ -237,4 +273,14 @@ void moveTerminalCursorDown(int numlines) {
   String cursorUp = String("\033[") + String(numlines) + String("B");
   Serial.print(cursorUp);
   Serial.print("\r");
+}
+
+void moveEyes (int x, int y){
+
+    double xPos = map(x, 0, 100, X_POS_MID + X_POS_LEFT_OFFSET, X_POS_MID + X_POS_RIGHT_OFFSET);
+    double yPos = map(y, 0, 100, Y_POS_MID + Y_POS_DOWN_OFFSET, Y_POS_MID + Y_POS_UP_OFFSET);
+
+    pwm_.setPWM(X_SERVO, 0, xPos);
+    pwm_.setPWM(Y_SERVO, 0, yPos);   
+
 }

--- a/TOF_aim/src/TOF_aim.ino
+++ b/TOF_aim/src/TOF_aim.ino
@@ -17,6 +17,7 @@
   Author: Bob Glicksman, Jim Schrempp
   Date: 1/14/22
     
+  rev 0.9.  Added Eye Servo control. Code still runs without eye servo board.
   rev 0.8.  Filter out spurious data readings by making sure that adjacent pixel values
       are valid data. Also fixed the reported smallest range coordinates to correspond
       to the prettyPrint() display coordinates.
@@ -143,11 +144,11 @@ void setup()
     pwm_.setPWM(L_UPPERLID_SERVO, 0, LEFT_UPPER_OPEN);
     pwm_.setPWM(R_UPPERLID_SERVO, 0, RIGHT_UPPER_OPEN);
     moveEyes(0,0);
-    delay(1000);
+    delay(500);
     moveEyes(50,50);
-    delay(1000);
+    delay(500);
     moveEyes(100,100);
-    delay (1000);
+    delay (500);
 
 
   // indicate that setup() is complete

--- a/TOF_aim/src/eyeservosettings.h
+++ b/TOF_aim/src/eyeservosettings.h
@@ -1,0 +1,55 @@
+/*
+ * eyeservosettings
+ * Part of the animatronic exploration of Team Practical Projects
+ * https://github.com/TeamPracticalProjects
+ * 
+ * These are the settings that are used to position the eye control
+ * servos. They depend on your particular eye mechanism, the servos you
+ * use and how the horns are attached to the servo shafts.
+ * 
+ * You should run the AnimatronicEyesCalibration.ino firmware to determine
+ * the values to put in this file.
+ * 
+ * You can select the set of values to use by uncommenting a #define
+ *    
+ */ 
+
+#define SETTINGS_JIMS
+//#define SETTINGS_BOBG
+
+
+// Servo Positions
+// Use the calibration test code to figure the correct values for each.
+// THE CALIBRATION TEST WILL PRINT A SET OF DEFINES THAT YOU CAN COPY
+// AND PASTE OVER THE ONES BELOW. 
+// -------------------------------------------------------------------
+// -------------------------------------------------------------------
+
+#ifdef SETTINGS_JIMS
+ 
+  #define X_POS_MID 400
+  #define X_POS_LEFT_OFFSET 141
+  #define X_POS_RIGHT_OFFSET -121
+
+  #define Y_POS_MID 407
+  #define Y_POS_UP_OFFSET 98
+  #define Y_POS_DOWN_OFFSET -82
+
+  #define LEFT_UPPER_CLOSED 486
+  #define LEFT_UPPER_OPEN 287
+
+  #define LEFT_LOWER_CLOSED 258
+  #define LEFT_LOWER_OPEN 450
+
+  #define RIGHT_UPPER_CLOSED 261
+  #define RIGHT_UPPER_OPEN 469
+
+  #define RIGHT_LOWER_CLOSED 509
+  #define RIGHT_LOWER_OPEN 256
+
+#endif
+
+
+
+// -------------------------------------------------------------------
+// -------------------------------------------------------------------


### PR DESCRIPTION
Basic eye servo control is in place. If servo board is not connected, the code will still run. You need to:

1. change the #define in eyeservosettings.h to be SETTINGS_BOBG and make sure they correspond to your eye calibration settings. Best might be to just copy over your eyeservosettings.h file from your Animatronics repository.
2. Connect the Adafruit servo control board to the I2C bus that has the TOF sensor. No other settings were necessary.

When the code starts setup() puts the eyes to lower left, pause, middle, pause, upper right, pause - all with eye lids open. This is to confirm that your servo calibration settings are correct. We can remove it later.

Now as the sensor code provides a focus point, the eyes will go there.

Note that right now it seems up/down and right/left are reversed. I can look into that, but I wanted to get this code to you quickly so you can experiment too. If you find this problem and want to change it, please do.