### PR TITLE
Fixed idle chatter

### DIFF
--- a/TOF_aim/src/TOF_aim.ino
+++ b/TOF_aim/src/TOF_aim.ino
@@ -15,7 +15,8 @@
   This firmware is based upon the example 1 code in the Sparkfun library.    
   
   Author: Bob Glicksman, Jim Schrempp
-  Date: 2/1/22
+  Date: 2/23/22
+  rev 2.0   expanded to use zones 0 and 7
   rev 1.9   moved wire initialization from ttp_tof to the .ino file setup()
   rev 1.8   moved TOF code into a class module
   rev 1.7   resolved bugs in avg and score array transversal
@@ -119,8 +120,8 @@ void loop() {
             if ((focusX >= 0) && (focusY >= 0)) {
                 static int xCurrentPos = 50;
                 static int yCurrentPos = 50;
-                int xPos = map(focusX,1,6, 20,80);   
-                int yPos = map(focusY,1,6, 80,20);
+                int xPos = map(focusX,0,7, 20,80);   
+                int yPos = map(focusY,0,7, 80,20);
                 xCurrentPos = xCurrentPos + (0.1 * (xPos - xCurrentPos));
                 yCurrentPos = yCurrentPos + (0.1 * (yPos - yCurrentPos));
                 moveEyeLids(100);  

--- a/TOF_aim/src/TPP_TOF.cpp
+++ b/TOF_aim/src/TPP_TOF.cpp
@@ -15,6 +15,9 @@
     (c) Copyright 2022 Bob Glicksman and Jim Schrempp
 
     This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+
+2022 02 23  change to reduce chatter. 
+
 */
 
 #include <TPP_TOF.h>
@@ -90,6 +93,9 @@ void TPP_TOF::initTOF(){
             }
 
         }
+#ifdef CONTINUOUS_DEBUG_DISPLAY
+        moveTerminalCursorDown(20);
+#endif
         Serial.println("Calibration data:");
         prettyPrint(calibration);
         Serial.println("End of calibration data\n");
@@ -125,12 +131,7 @@ void TPP_TOF::processMeasuredData(VL53L5CX_ResultsData measurementData, int32_t 
             // data is good and in range, check if background
           
             // check new data against calibration value
-            temp = measuredData - calibration[i];
-            
-            // take the absolute value
-            if(temp < 0) {
-                temp = -temp;
-            }
+            temp = abs(measuredData - calibration[i]);
 
             if(temp <= NOISE_RANGE) { 
                     // zero out noise  
@@ -290,15 +291,12 @@ void TPP_TOF::getPOI(pointOfInterest *pPOI){
                     // Get the average distance of this zone
                     int avgDistThisZone = avgdistZone(thisZone, adjustedData);
 
-
                     int score = scoreZone(thisZone, adjustedData);
-
 
                     secondTable[thisZone] = avgDistThisZone; 
 
-
                     // test for the smallest value that is a significant zone
-                    if( (avgDistThisZone > 0) && (avgDistThisZone < smallestValue) &&
+                    if( (avgDistThisZone > NOISE_RANGE) && (avgDistThisZone < smallestValue) &&
                         (validate(score) == true) ) {
 
                         focusX = x;


### PR DESCRIPTION
I found that in the getPOI code we tested average zone distance, but did not screen out zones based on NOISE_RANGE. This bug has been present since we went to using the average zone distance. I have added this test and the chatter went away.

We now test for NOISE_RANGE in two areas, both processMeasuredData() and in getPOI(). It could be argued that we should not test for NOISE_RANGE in processedMeasuredData() and leave these potentially spurious readings in the data to be later filtered out in getPOI(). I did not do this.

Also ... I found that in TOF_aim we were mapping only zones 1-6 to the eyes. I thought we had changed that to be 0-7. I made that change in this commit, giving the eyes a broader view.